### PR TITLE
docs: Replace OpenCollective button with GitHub Sponsors button

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -12,8 +12,8 @@
 </p>
 
 <p>
-    <a href="https://opencollective.com/privacyguides">
-        <img src="https://img.shields.io/opencollective/all/privacyguides">
+    <a href="https://github.com/sponsors/privacyguides#sponsors">
+        <img src="https://img.shields.io/github/sponsors/privacyguides">
     </a>
 </p>
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -14,6 +14,7 @@
 <p>
     <a href="https://github.com/sponsors/privacyguides#sponsors">
         <img src="https://img.shields.io/github/sponsors/privacyguides">
+    </a>
     <a href="https://discuss.privacyguides.net">
         <img src="https://img.shields.io/discourse/users?label=Join%20our%20forum&logo=discourse&server=https%3A%2F%2Fdiscuss.privacyguides.net&style=social">
     </a>


### PR DESCRIPTION
Change proposed in this PR:

- Apply the change in https://github.com/privacyguides/privacyguides.org/pull/2791 to the GitHub organization README